### PR TITLE
Remove unnecessary divider from login menu

### DIFF
--- a/src/LoginMenu.ts
+++ b/src/LoginMenu.ts
@@ -90,7 +90,6 @@ export default class LoginMenu extends EventHandler {
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                aria-expanded="false"><i class="fa fa-user" aria-hidden="true"></i> <span>Unknown</span></a>
             <ul class="dropdown-menu">
-                <li role="separator" class="divider"></li>
                 <li><a href="#" id="logout_link">Logout</a></li>
             </ul>
         </li>`;


### PR DESCRIPTION
The divider in the user menu is not necessary and can be removed.

**Before**
![grafik](https://user-images.githubusercontent.com/5851088/63704702-ddb0a100-c82b-11e9-9033-2f10f8e3bc09.png)


**After**
![grafik](https://user-images.githubusercontent.com/5851088/63704660-c671b380-c82b-11e9-9cca-ae62f612f3ee.png)

