### PR TITLE
Use hyphen instead of underscore for api key variable

### DIFF
--- a/phovea_security_flask/flask_login_impl.py
+++ b/phovea_security_flask/flask_login_impl.py
@@ -141,7 +141,7 @@ class NamespaceLoginManager(security.SecurityManager):
 
   def _load_user_from_request(self, request):
     # first, try to login using the api_key url arg
-    api_key = request.headers.get('api_key')
+    api_key = request.headers.get('api-key')
     if api_key:
       user = self._load_user_from_key(api_key)
       if user:

--- a/phovea_security_flask/flask_login_impl.py
+++ b/phovea_security_flask/flask_login_impl.py
@@ -141,7 +141,7 @@ class NamespaceLoginManager(security.SecurityManager):
 
   def _load_user_from_request(self, request):
     # first, try to login using the api_key url arg
-    api_key = request.headers.get('api-key')
+    api_key = request.headers.get('apiKey')
     if api_key:
       user = self._load_user_from_key(api_key)
       if user:


### PR DESCRIPTION
Fixes datavisyn/tdp_bayer_jamborees#79

Related to https://github.com/datavisyn/tdp_comments/pull/72


### Summary
* change `api_key` to `api-key`

See [issue](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/?highlight=disappearing%20http%20headers#missing-disappearing-http-headers)

Further investigation will be done